### PR TITLE
Added text alert for no items to display.

### DIFF
--- a/src/directives/auto-complete.component.ts
+++ b/src/directives/auto-complete.component.ts
@@ -12,7 +12,8 @@ const defaultOpts = {
   autocorrect       : "off",
   spellcheck        : "off",
   type              : "search",
-  value             : ""
+  value             : "",
+  noItems           : ""
 };
 
 @Component({
@@ -34,6 +35,7 @@ const defaultOpts = {
                 <ion-auto-complete-item [data]="suggestion" [keyword]="keyword" [labelAttribute]="dataProvider.labelAttribute"></ion-auto-complete-item>
             </ion-item>
         </ion-list>
+        <p *ngIf="suggestions.length == 0 && showList && options.noItems">{{ options.noItems }}</p>
   `,
   selector      : 'ion-auto-complete'
 })


### PR DESCRIPTION
I just added a `<p>` element that can display customized message to alert user that no items are found with that keyword.

You can customize your message in your HTML by adding a `options.noItems` parameter:

```html
<ion-auto-complete [dataProvider]="ownDataProvicer" (itemSelected)="itemSelected()" [options]="{ noItems: 'No items found'}" #ownSelect></ion-auto-complete>
```