### PR TITLE
Added option to hideItemList on clearValue

### DIFF
--- a/src/autocomplete.component.ts
+++ b/src/autocomplete.component.ts
@@ -149,8 +149,11 @@ export class AutoCompleteComponent {
   /**
    * clear current input value
    */
-  public clearValue() {
+  public clearValue(hideItemList: boolean = false) {
     this.keyword = null;
+    if (hideItemList) {
+      this.hideItemList();
+    }
     return;
   }
 }


### PR DESCRIPTION
This will allow people to hide the item list after clearing the value by setting a default-initialized parameter (default `false`). 
Calling `clearValue(true)` will also invoke the private method `hideItemList()`.