### PR TITLE
Support RxJS Subject as a result type

### DIFF
--- a/src/autocomplete.component.ts
+++ b/src/autocomplete.component.ts
@@ -110,8 +110,10 @@ export class AutoCompleteComponent {
     }
 
     let result = this.dataProvider.getResults(this.keyword);
-    // if result is instanceof Subject, convert it to observable
-    result = result instanceof Subject?result.asObservable():result;
+    // if result is instanceof Subject, use it asObservable
+    if(result instanceof Subject){
+      result = result.asObservable();
+    }
     // if query is async
     if (result instanceof Observable) {
       result

--- a/src/autocomplete.component.ts
+++ b/src/autocomplete.component.ts
@@ -1,5 +1,5 @@
 import {Component, Input, Output, EventEmitter, TemplateRef, ViewChild, ElementRef} from '@angular/core';
-import {Observable} from 'rxjs';
+import {Observable,Subject} from 'rxjs';
 
 // searchbar default options
 const defaultOpts = {
@@ -110,7 +110,8 @@ export class AutoCompleteComponent {
     }
 
     let result = this.dataProvider.getResults(this.keyword);
-
+    // if result is instanceof Subject, convert it to observable
+    result = result instanceof Subject?result.asObservable():result;
     // if query is async
     if (result instanceof Observable) {
       result


### PR DESCRIPTION
Hello,

This pull request will resolve issue #52.

Actually, I have found a solution to my problem without changing the code of your component. I will explain my point then it's up to you whether to include this in the component or to add a hint in the documentation.

As I have explained in my issue #52, I wanted to return a result of type Subject which allows me to emit values in the future when they're available. After some research, I've realized that the Subject class has a method called [asObservable()](https://github.com/Reactive-Extensions/RxJS/blob/master/doc/api/core/operators/asobservable.md) that can be used to hide the identity of the source sequence. Thus, instead of returning a subject instance, I used subject.asObservable() and my problem was resolved.

To Summarize, we have two options here : 

- The first option is to say, Developers must always return a result of type observable which is obviously possible thanks to the asObservable() operator. 

- The second option is about providing more flexibility which is the subject of my pull request. As you can see in the commit, I've added a test to handle result of type Subject. So developers will have the possibility of returning an Observable or a subclass of Observable such as Subject, without the need of calling the asObservable method.
