### PR TITLE
Added events for itemsShown and itemsHidden. The primary use case is …

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ In order to implement a custom Item component, you need to follow these steps:
 ## Events ##
 
 **itemSelected($event)** - fired when item is selected (clicked)
+**itemsShown($event)** - fired when items are shown
+**itemsHidden($event)** - fired when items are hidden
 **ionAutoInput($event)** - fired when user inputs
 
 ## Searchbar options ##

--- a/src/autocomplete.component.ts
+++ b/src/autocomplete.component.ts
@@ -77,15 +77,31 @@ export class AutoCompleteComponent {
   @Input() public template: TemplateRef<any>;
   @Input() public useIonInput: boolean;
   @Output() public itemSelected:  EventEmitter<any>;
+  @Output() public itemsShown:  EventEmitter<any>;
+  @Output() public itemsHidden:  EventEmitter<any>;
   @Output() public ionAutoInput:  EventEmitter<string>;
 
   @ViewChild('searchbarElem') searchbarElem;
   @ViewChild('inputElem') inputElem;
 
   public suggestions:  string[];
-  public showList:     boolean;
+
+  public get showList(): boolean {
+    return this._showList;
+  }
+  public set showList(value: boolean) {
+    if (this._showList === value) {
+      return;
+    }
+
+    this._showList = value;
+    this.showListChanged = true;
+  }
+  private _showList: boolean;
+
   private defaultOpts:  any;
   private selection: any;
+  private showListChanged: boolean = false;
 
   /**
    * create a new instace
@@ -93,13 +109,22 @@ export class AutoCompleteComponent {
   public constructor() {
     this.keyword = null;
     this.suggestions = [];
-    this.showList = false;
+    this._showList = false;
     this.itemSelected = new EventEmitter<any>();
+    this.itemsShown = new EventEmitter<any>();
+    this.itemsHidden = new EventEmitter<any>();
     this.ionAutoInput = new EventEmitter<string>();
     this.options = {};
 
     // set default options
     this.defaultOpts = defaultOpts;
+  }
+
+  ngAfterViewChecked() {
+    if (this.showListChanged) {
+      this.showListChanged = false;
+      this.showList ? this.itemsShown.emit() : this.itemsHidden.emit();
+    }
   }
 
   /**


### PR DESCRIPTION
…to support auto-scrolling the items list into view if it appears below the bottom of its parent container.

Emitting events in the setter for showList caused them to be handled before the items were actually rendered in the dom. Emitting in ngAfterViewChecked seems reliable.